### PR TITLE
Typo fix

### DIFF
--- a/src/main/resources/localization/ThMod_Fnh_powers.json
+++ b/src/main/resources/localization/ThMod_Fnh_powers.json
@@ -45,14 +45,14 @@
     ]
   },
   "TempStrength": {
-    "NAME": "Temproy Strength",
+    "NAME": "Temporary Strength",
     "DESCRIPTIONS": [
       "Your next blow deals additional  #b",
       " damage."
     ]
   },
   "TempStrengthLoss": {
-    "NAME": "Temproy Strength Loss",
+    "NAME": "Temporary Strength Loss",
     "DESCRIPTIONS": [
       "The damage of this creature is lowered by  #b",
       " this turn."
@@ -123,7 +123,7 @@
     ]
   },
   "SingularityPower": {
-    "NAME": "Singualrity",
+    "NAME": "Singularity",
     "DESCRIPTIONS": [
       "Whenever you play a card that costs 0 , a random #yAttack in your hand deals #b",
       " additional damage this combat."
@@ -194,7 +194,7 @@
     ]
   },
   "PropBagPower": {
-    "NAME": "Portable Prop Bagr",
+    "NAME": "Portable Prop Bag",
     "DESCRIPTIONS": [
       "When the battle ends,you'll lose  #y",
       "."

--- a/src/main/resources/localization/ThMod_Fnh_relics.json
+++ b/src/main/resources/localization/ThMod_Fnh_relics.json
@@ -109,7 +109,7 @@
     "NAME": "Big Shroom Bag",
     "FLAVOR": "A large version of shroom bag.",
     "DESCRIPTIONS": [
-      "Replaces #rShroom #rBag . NL Parasite cards can now be played. Playing a #yParasite will heal #b3 HP and draw #b2 card, then Exhausts it."
+      "Replaces #rShroom #rBag . NL Parasite cards can now be played. Playing a #yParasite will heal #b3 HP and draw #b2 card, then Exhaust the Parasite."
     ]
   },
   "WWWWWWWWWWWW": {


### PR DESCRIPTION
There were some oddities in buff/debuff names, and description of Shroom Bag implied that the card you draw is the one that will be exhausted.